### PR TITLE
sim: allow submitting solutions written in C++20

### DIFF
--- a/subprojects/sim/include/sim/submissions/old_submission.hh
+++ b/subprojects/sim/include/sim/submissions/old_submission.hh
@@ -34,6 +34,7 @@ struct OldSubmission {
         (CPP17, 4, "cpp17")
         (PYTHON, 5, "python")
         (RUST, 6, "rust")
+        (CPP20, 7, "cpp20")
     );
 
     // Initial and final values may be combined, but special not
@@ -94,6 +95,7 @@ constexpr const char* to_string(OldSubmission::Language x) {
     case OldSubmission::Language::CPP11: return "C++11";
     case OldSubmission::Language::CPP14: return "C++14";
     case OldSubmission::Language::CPP17: return "C++17";
+    case OldSubmission::Language::CPP20: return "C++20";
     case OldSubmission::Language::PASCAL: return "Pascal";
     case OldSubmission::Language::PYTHON: return "Python";
     case OldSubmission::Language::RUST: return "Rust";
@@ -106,7 +108,8 @@ constexpr const char* to_extension(OldSubmission::Language x) {
     case OldSubmission::Language::C11: return ".c";
     case OldSubmission::Language::CPP11:
     case OldSubmission::Language::CPP14:
-    case OldSubmission::Language::CPP17: return ".cpp";
+    case OldSubmission::Language::CPP17:
+    case OldSubmission::Language::CPP20: return ".cpp";
     case OldSubmission::Language::PASCAL: return ".pas";
     case OldSubmission::Language::PYTHON: return ".py";
     case OldSubmission::Language::RUST: return ".rs";
@@ -119,7 +122,8 @@ constexpr const char* to_mime(OldSubmission::Language x) {
     case OldSubmission::Language::C11: return "text/x-csrc";
     case OldSubmission::Language::CPP11:
     case OldSubmission::Language::CPP14:
-    case OldSubmission::Language::CPP17: return "text/x-c++src";
+    case OldSubmission::Language::CPP17:
+    case OldSubmission::Language::CPP20: return "text/x-c++src";
     case OldSubmission::Language::PASCAL: return "text/x-pascal";
     case OldSubmission::Language::PYTHON: return "text/x-python";
     case OldSubmission::Language::RUST: return "text/x-rust";

--- a/subprojects/sim/include/sim/submissions/submission.hh
+++ b/subprojects/sim/include/sim/submissions/submission.hh
@@ -30,6 +30,7 @@ struct Submission {
         (CPP17, 4, "cpp17")
         (PYTHON, 5, "python")
         (RUST, 6, "rust")
+        (CPP20, 7, "cpp20")
     );
 
     // Initial and final values may be combined, but special not

--- a/subprojects/sim/src/job_server/job_handlers/judge_or_rejudge_submission.cc
+++ b/subprojects/sim/src/job_server/job_handlers/judge_or_rejudge_submission.cc
@@ -147,6 +147,7 @@ void judge_or_rejudge_submission(
         case Submission::Language::CPP11: return sim::SolutionLanguage::CPP11;
         case Submission::Language::CPP14: return sim::SolutionLanguage::CPP14;
         case Submission::Language::CPP17: return sim::SolutionLanguage::CPP17;
+        case Submission::Language::CPP20: return sim::SolutionLanguage::CPP20;
         case Submission::Language::PASCAL: return sim::SolutionLanguage::PASCAL;
         case Submission::Language::PYTHON: return sim::SolutionLanguage::PYTHON;
         case Submission::Language::RUST: return sim::SolutionLanguage::RUST;

--- a/subprojects/sim/src/web_server/old/submissions_api.cc
+++ b/subprojects/sim/src/web_server/old/submissions_api.cc
@@ -900,6 +900,8 @@ void Sim::api_submission_add() {
         slang = OldSubmission::Language::CPP14;
     } else if (slang_str == "cpp17") {
         slang = OldSubmission::Language::CPP17;
+    } else if (slang_str == "cpp20") {
+        slang = OldSubmission::Language::CPP20;
     } else if (slang_str == "pascal") {
         slang = OldSubmission::Language::PASCAL;
     } else if (slang_str == "python") {

--- a/subprojects/sim/src/web_server/static/kit/scripts.js
+++ b/subprojects/sim/src/web_server/static/kit/scripts.js
@@ -4058,6 +4058,9 @@ function add_submission_impl(as_oldmodal, url, api_url, problem_field_elem, mayb
 					}).add('<option>', {
 						value: 'cpp17',
 						text: 'C++17',
+					}).add('<option>', {
+						value: 'cpp20',
+						text: 'C++20',
 						selected: true
 					}).add('<option>', {
 						value: 'pascal',

--- a/subprojects/simlib/include/simlib/sim/judge_worker.hh
+++ b/subprojects/simlib/include/simlib/sim/judge_worker.hh
@@ -154,7 +154,8 @@ enum class SolutionLanguage {
     CPP11,
     CPP14,
     CPP17,
-    CPP = CPP17,
+    CPP20,
+    CPP = CPP20,
     PASCAL,
     PYTHON,
     RUST,
@@ -189,7 +190,8 @@ inline SolutionLanguage filename_to_lang(const StringView& filename) {
         // If missing one, then update above ifs
         return res;
     case SolutionLanguage::CPP11:
-    case SolutionLanguage::CPP14: break;
+    case SolutionLanguage::CPP14:
+    case SolutionLanguage::CPP17: break;
     }
 
     THROW("Should not reach here");

--- a/subprojects/simlib/src/sim/judge_worker.cc
+++ b/subprojects/simlib/src/sim/judge_worker.cc
@@ -119,6 +119,11 @@ std::unique_ptr<judge::language_suite::Suite> lang_to_suite(SolutionLanguage lan
             judge::language_suite::Cpp_GCC::Standard::Cpp17
         );
     } break;
+    case SolutionLanguage::CPP20: {
+        return std::make_unique<judge::language_suite::Cpp_GCC>(
+            judge::language_suite::Cpp_GCC::Standard::Cpp20
+        );
+    } break;
     case SolutionLanguage::PASCAL: {
         return std::make_unique<judge::language_suite::Pascal>();
     } break;

--- a/subprojects/simlib/test/sim/judge/language_suite/cpp_clang.cc
+++ b/subprojects/simlib/test/sim/judge/language_suite/cpp_clang.cc
@@ -22,7 +22,7 @@ int main() {
 
 // NOLINTNEXTLINE
 TEST(sim_judge_compiler, cpp_clang) {
-    auto suite = Cpp_Clang{Cpp_Clang::Standard::Cpp17};
+    auto suite = Cpp_Clang{Cpp_Clang::Standard::Cpp20};
     ASSERT_EQ(suite.is_supported(), path_exists("/usr/bin/clang++"));
     if (suite.is_supported()) {
         test_compiled_language_suite(

--- a/subprojects/simlib/test/sim/judge/language_suite/cpp_gcc.cc
+++ b/subprojects/simlib/test/sim/judge/language_suite/cpp_gcc.cc
@@ -22,7 +22,7 @@ int main() {
 
 // NOLINTNEXTLINE
 TEST(sim_judge_compiler, cpp_gcc) {
-    auto suite = Cpp_GCC{Cpp_GCC::Standard::Cpp17};
+    auto suite = Cpp_GCC{Cpp_GCC::Standard::Cpp20};
     ASSERT_EQ(suite.is_supported(), path_exists("/usr/bin/g++"));
     if (suite.is_supported()) {
         test_compiled_language_suite(


### PR DESCRIPTION
As the title says, this PR enables the user to submit solutions written in C++20 and sets it as the default submission language.  
Note: I didn't change the database schema, as a language ID of 7 fits perfectly into a `tinyint(3)` as previously defined.